### PR TITLE
Cls.java:Use escape sequence to clear console

### DIFF
--- a/src/Cls.java
+++ b/src/Cls.java
@@ -2,11 +2,11 @@ import java.io.IOException;
 
 public class Cls {
     public static void clear() {
-        try {
-            new ProcessBuilder("cmd", "/c", "cls").inheritIO().start().waitFor();
-        } catch (IOException | InterruptedException e) {
-            e.printStackTrace();
-        }
+        // \033[H -> Move cursor
+        // \033[2J -> Clear Screen
+        System.out.println("\033[H\033[2J");
+        // Flush stdout
+        System.out.flush();
     }
 
     public static void setTitle() {


### PR DESCRIPTION
手元のMac, Windows, Ubuntu上のJava 11系で正常な動作を確認しました。
